### PR TITLE
Avoid casting using `as` where possible.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.2
+
+- Optimizes to avoid or cheapen `as` casts where possible.
+  Uses `as dynamic` with a context type where a cast cannot be avoided,
+  for better dart2js performance.
+
 ## 1.1.1
 
 - Populate the pubspec's `repository` field.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -12,3 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 include: package:lints/recommended.yaml
+
+linter:
+  rules:
+    - avoid_annotating_with_dynamic
+    - avoid_escaping_inner_quotes
+    - avoid_final_parameters
+    - avoid_multiple_declarations_per_line
+    - avoid_relative_lib_imports
+    - avoid_type_to_string
+    - directives_ordering
+    - leading_newlines_in_multiline_strings
+    - omit_local_variable_types
+    - prefer_relative_imports
+    - use_if_null_to_convert_nulls_to_bools

--- a/example/bigint_json.dart
+++ b/example/bigint_json.dart
@@ -19,7 +19,7 @@
 /// Choosing other representations is a matter of adapting the
 /// `processNum`/`processUnknown` overrides in the [JsonProcessor]
 /// sub-classes.
-import 'package:jsontool/jsontool.dart';
+import "package:jsontool/jsontool.dart";
 
 /// Parses a JSON string into JSON-like object structure.
 ///

--- a/lib/src/json/json_structure_validator.dart
+++ b/lib/src/json/json_structure_validator.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import "package:jsontool/jsontool.dart";
+import "../jsontool.dart";
 
 /// A progressive JSON structure sink validator.
 ///

--- a/lib/src/json/processor/processor.dart
+++ b/lib/src/json/processor/processor.dart
@@ -14,8 +14,9 @@
 
 // A generalized processor for JSON source which takes elements from a
 // reader, then leaves the processing to user overridable methods.
-import '../sink/sink.dart';
-import '../reader/reader.dart';
+
+import "../reader/reader.dart";
+import "../sink/sink.dart";
 
 /// A generalized JSON processor.
 ///

--- a/lib/src/json/reader/byte_reader.dart
+++ b/lib/src/json/reader/byte_reader.dart
@@ -476,10 +476,10 @@ class JsonByteReader implements JsonReader<Uint8List> {
   num? tryNum() => _scanNumber(false, false);
 
   @override
-  double expectDouble() => _scanNumber(true, true) as double;
+  double expectDouble() => _scanNumber(true, true) as dynamic;
 
   @override
-  double? tryDouble() => _scanNumber(true, false) as double?;
+  double? tryDouble() => _scanNumber(true, false) as dynamic;
 
   num? _scanNumber(bool asDouble, bool throws) {
     var char = _nextNonWhitespaceChar();

--- a/lib/src/json/reader/reader.dart
+++ b/lib/src/json/reader/reader.dart
@@ -15,10 +15,10 @@
 import "dart:typed_data";
 
 import "../sink/sink.dart";
-import "string_reader.dart";
 import "byte_reader.dart";
 import "object_reader.dart";
 import "reader_validator.dart";
+import "string_reader.dart";
 
 export "string_reader.dart" show StringSlice;
 

--- a/lib/src/json/reader/reader_validator.dart
+++ b/lib/src/json/reader/reader_validator.dart
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import "../json_structure_validator.dart";
-import '../sink/sink.dart';
+import "../sink/sink.dart";
 import "reader.dart";
 import "util.dart";
 

--- a/lib/src/json/reader/string_reader.dart
+++ b/lib/src/json/reader/string_reader.dart
@@ -440,10 +440,10 @@ class JsonStringReader implements JsonReader<StringSlice> {
   num? tryNum() => _scanNumber(false, false);
 
   @override
-  double expectDouble() => _scanNumber(true, true) as double;
+  double expectDouble() => _scanNumber(true, true) as dynamic;
 
   @override
-  double? tryDouble() => _scanNumber(true, false) as double?;
+  double? tryDouble() => _scanNumber(true, false) as dynamic;
 
   num? _scanNumber(bool asDouble, bool throws) {
     var char = _nextNonWhitespaceChar();

--- a/lib/src/json/sink/sink_validator.dart
+++ b/lib/src/json/sink/sink_validator.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:jsontool/src/json/json_structure_validator.dart';
+import "../json_structure_validator.dart";
 
 import "sink.dart";
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 name: jsontool
-version: 1.1.1
+version: 1.1.2
 description:
   Low-level tools for working with JSON without creating intermediate objects.
 repository: https://github.com/lrhn/json-tool

--- a/test/example_test.dart
+++ b/test/example_test.dart
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
+import "dart:async";
 
-import 'package:test/test.dart';
-import '../example/planets_json.dart' as planets;
-import '../example/bigint_json.dart' as bigint;
+import "package:test/test.dart";
+
+import "../example/bigint_json.dart" as bigint;
+import "../example/planets_json.dart" as planets;
 
 const planetsOutput = """
 Mercury is a Rock Planet and has a volume 0.05 times that of the Earth

--- a/test/jsonbuilder_test.dart
+++ b/test/jsonbuilder_test.dart
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import "package:test/test.dart";
 import "package:jsontool/jsontool.dart";
+import "package:test/test.dart";
 
 void main() {
   JsonReader read(String source) => JsonReader.fromString(source);
@@ -106,7 +106,11 @@ void main() {
     expect(objectFold(read('{"x": 1}')), 1);
     expect(objectFold(read('{"x": 1, "y": 2, "z": 3}')), 6);
     var objectFoldKey = jsonFoldObject(
-        jsonInt, () => [], (List a, String? key, int b) => a..add(key)..add(b));
+        jsonInt,
+        () => [],
+        (List a, String? key, int b) => a
+          ..add(key)
+          ..add(b));
     expect(objectFoldKey(read('{"x": 1, "y": 2, "z": 3}')),
         ["x", 1, "y", 2, "z", 3]);
   });

--- a/test/jsonreader_test.dart
+++ b/test/jsonreader_test.dart
@@ -15,8 +15,8 @@
 import "dart:convert";
 import "dart:typed_data";
 
-import "package:test/test.dart";
 import "package:jsontool/jsontool.dart";
+import "package:test/test.dart";
 
 void main() {
   for (var kind in ["string", "utf8", "object"]) {
@@ -93,7 +93,7 @@ void testReader(JsonReader Function(String source) read) {
     var g2a = read(r'"\n"');
     expect(g2a.expectString(), "\n");
     var g3 = read(r'"\b\t\n\r\f\\\"\/\ufffd"');
-    expect(g3.expectString(), "\b\t\n\r\f\\\"/\ufffd");
+    expect(g3.expectString(), '\b\t\n\r\f\\"/\ufffd');
   });
 
   test("parse array", () {

--- a/test/jsonsink_test.dart
+++ b/test/jsonsink_test.dart
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 import "dart:convert";
-import "package:test/test.dart";
+
 import "package:jsontool/jsontool.dart";
+import "package:test/test.dart";
 
 import "src/json_data.dart";
 

--- a/test/objectreader_test.dart
+++ b/test/objectreader_test.dart
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import "package:test/test.dart";
 import "package:jsontool/jsontool.dart";
+import "package:test/test.dart";
 
 void main() {
-  test('simple rebuild object', () {
-    Object? jsonObject = {'a': 1, 'b': 2};
+  test("simple rebuild object", () {
+    Object? jsonObject = {"a": 1, "b": 2};
 
     final jsonReader = JsonReader.fromObject(jsonObject);
 
@@ -30,7 +30,7 @@ void main() {
     expect(newJson, jsonObject);
   });
 
-  test('simple rebuild array', () {
+  test("simple rebuild array", () {
     Object? jsonObject = [1, 2, 3];
 
     final jsonReader = JsonReader.fromObject(jsonObject);

--- a/test/src/json_data.dart
+++ b/test/src/json_data.dart
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const simpleJson = '''{
+const simpleJson = '''
+{
   "key1": ["value11", "value12"],
   "key2": ["value21"],
   "key3": []
 }''';
 
-const complexJson = r'''[
+const complexJson = r'''
+[
   0,
   1.1e+2,
   1.1e-2,


### PR DESCRIPTION
Where not possible, use `as dynamic` with a context type for better web-performance.