### PR TITLE
Fix JsonReader.expectAnyValue for objects and null

### DIFF
--- a/lib/src/json/reader/byte_reader.dart
+++ b/lib/src/json/reader/byte_reader.dart
@@ -705,7 +705,7 @@ class JsonByteReader implements JsonReader<Uint8List> {
         return;
       case $lbrace:
         _index++;
-        sink.startArray();
+        sink.startObject();
         var key = nextKey();
         while (key != null) {
           sink.addKey(key);

--- a/lib/src/json/reader/object_reader.dart
+++ b/lib/src/json/reader/object_reader.dart
@@ -390,6 +390,7 @@ class JsonObjectReader implements JsonReader<Object?> {
       }
       if (tryNull()) {
         sink.addNull();
+        return;
       }
       var number = tryNum();
       if (number != null) {

--- a/test/jsonreader_test.dart
+++ b/test/jsonreader_test.dart
@@ -216,7 +216,7 @@ void testReader(JsonReader Function(String source) read) {
   });
 
   test("skipAnyValue", () {
-    var g1 = read(r'{"a":[[[[{"a":2}]]]],"b":2}');
+    var g1 = read(r'{"a":[[[[{"a":2},null,true,false,[],{},"YES"]]]],"b":2}');
     g1.expectObject();
     expect(g1.nextKey(), "a");
     g1.skipAnyValue();
@@ -226,6 +226,24 @@ void testReader(JsonReader Function(String source) read) {
   });
 
   test("expectAnyValue", () {
+    var anyValue = r'[[[[{"a":2},null,true,false,[],{},"YES"]]]]';
+
+    var g1 = read('{"a":$anyValue,"b":2}');
+    g1.expectObject();
+    expect(g1.nextKey(), "a");
+
+    var out = StringBuffer();
+    var w = jsonStringWriter(out);
+    g1.expectAnyValue(w);
+    var skipped = out.toString();
+    expect(skipped, anyValue);
+
+    expect(g1.nextKey(), "b");
+    expect(g1.expectInt(), 2);
+    expect(g1.nextKey(), null);
+  });
+
+  test("expectAnyValueSource", () {
     var g1 = read(r'{"a":["test"],"b":2}');
     g1.expectObject();
     var key = g1.nextKeySource();


### PR DESCRIPTION
Adds test cases for `null` and `{"a":2}` with `JsonReader.expectAnyValue`, and fixes bugs for null and objects not being handled correctly.